### PR TITLE
Added an initializer with delegate

### DIFF
--- a/OROpenSubtitleDownloader.h
+++ b/OROpenSubtitleDownloader.h
@@ -38,6 +38,9 @@ typedef enum {
 /// Use a custom user agent
 - (OROpenSubtitleDownloader *)initWithUserAgent:(NSString *)userAgent;
 
+/// Use a custom user agent
+- (OROpenSubtitleDownloader *)initWithUserAgent:(NSString *)userAgent delegate:(id<OROpenSubtitleDownloaderDelegate>) delegate NS_DESIGNATED_INITIALIZER;
+
 /// The object that recieves notifications for new subtitles
 @property (nonatomic, weak) NSObject <OROpenSubtitleDownloaderDelegate> *delegate;
 

--- a/OROpenSubtitleDownloader.m
+++ b/OROpenSubtitleDownloader.m
@@ -32,14 +32,19 @@ static NSString * const kRequest_SearchSubtitles = @"SearchSubtitles";
 #pragma mark Init
 
 - (OROpenSubtitleDownloader *)init {
-    return [self initWithUserAgent:[self generateUserAgent]];
+    return [self initWithUserAgent:[self generateUserAgent] delegate:nil];
 }
 
 - (OROpenSubtitleDownloader *)initWithUserAgent:(NSString *)userAgent {
+    return [self initWithUserAgent:userAgent delegate:nil];
+}
+
+- (OROpenSubtitleDownloader *)initWithUserAgent:(NSString *)userAgent delegate:(id<OROpenSubtitleDownloaderDelegate>) delegate
+{
     self = [super init];
     if (!self) return nil;
 
-
+    _delegate = delegate;
     _userAgent = userAgent;
     _blockResponses = [NSMutableDictionary dictionary];
     _state = OROpenSubtitleStateLoggingIn;

--- a/OROpenSubtitleDownloader.podspec
+++ b/OROpenSubtitleDownloader.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "OROpenSubtitleDownloader"
-  s.version      = "1.2.0"
+  s.version      = "1.2.1"
   s.summary      = "An Obj-C API for Searching and Downloading Subtitles from OpenSubtitles."
   s.homepage     = "https://github.com/orta/OROpenSubtitleDownloader"
   s.license      = { :type => 'BSD', :file => 'LICENSE' }


### PR DESCRIPTION
Since the init method calls the _Login_ method, there can be cases where the login completes before
the delegate is set via the property.

In this case, the delegate would never receive the `- (void)openSubtitlerDidLogIn:(OROpenSubtitleDownloader *)downloader;`
